### PR TITLE
Fix reloading plugins

### DIFF
--- a/DomReady/PluginManager.js
+++ b/DomReady/PluginManager.js
@@ -78,8 +78,8 @@ class PluginManager {
             return loaded;
         }
         try {
-            this.unload(name.toLowerCase());
-            this.load(name.toLowerCase());
+            this.unload(name);
+            this.load(name);
             console.log(`Plugin ${name} has been reloaded.`);
             return true;
         } catch (err) {


### PR DESCRIPTION
I have no idea why this is here. This forces plugins to be lowercase, thus any plugins depending on using discord settings tabs get mixed up 