### PR TITLE
Support multiple languages

### DIFF
--- a/DomReady/DISettings.js
+++ b/DomReady/DISettings.js
@@ -7,6 +7,7 @@ const Plugin = window.DI.require('./Structures/Plugin');
 class DISettings {
     constructor() {
         const plugin = new (class DiscordInjections extends Plugin { })();
+        DI.StateWatcher.on('languageChange', this.injectSettingsTab.bind(this));
         DI.StateWatcher.on('settingsOpened', this.injectSettingsTab.bind(this));
         DI.StateWatcher.on('settingsTab', type => {
             if (this.map.hasOwnProperty(type)) {
@@ -70,8 +71,10 @@ class DISettings {
     }
 
     injectSettingsTab() {
-        if (this.settingsTabs.childNodes[0].innerHTML !== 'User Settings') return;
-        let header = this.settingsTabs.querySelectorAll('.separator-3z7STW')[3];
+        if (!this.settingsTabs) return
+
+        const el = this.settingsTabs.querySelector(".itemDanger-3m3dwx")
+        let header = el.previousElementSibling
         this.settingsTabs.insertBefore(this.divider, header);
         this.settingsTabs.insertBefore(this.header, header);
         for (const key in this.map) {

--- a/DomReady/DISettings.js
+++ b/DomReady/DISettings.js
@@ -71,10 +71,10 @@ class DISettings {
     }
 
     injectSettingsTab() {
-        if (!this.settingsTabs) return
+        if (!this.settingsTabs) return;
 
-        const el = this.settingsTabs.querySelector(".itemDanger-3m3dwx")
-        let header = el.previousElementSibling
+        const el = this.settingsTabs.querySelector('.itemDanger-3m3dwx');
+        let header = el.previousElementSibling;
         this.settingsTabs.insertBefore(this.divider, header);
         this.settingsTabs.insertBefore(this.header, header);
         for (const key in this.map) {

--- a/DomReady/StateWatcher.js
+++ b/DomReady/StateWatcher.js
@@ -4,9 +4,7 @@ class StateWatcher extends EventEmitter {
     constructor() {
         super();
         this.observer = new MutationObserver(this._onMutation.bind(this));
-        let mutation = { childList: true, subtree: true };
-        this.observer.observe(document.querySelector(".app .layers"), mutation);
-
+        this.observe();
     }
 
     get settingsTabs() {
@@ -32,8 +30,19 @@ class StateWatcher extends EventEmitter {
         };
     }
 
+    observe() {
+        this.observer.disconnect();
+        let mutation = { childList: true, subtree: true };
+        this.observer.observe(document.querySelector(".app .layers"), mutation);
+        this.observer.observe(document.querySelector("html"), { attributes: true })
+    }
+
     _onMutation(muts) {
         //console.log(muts);
+
+        if (muts.length === 1 && muts[0].type === 'attributes' && muts[0].attributeName === 'lang') {
+            this.emit('languageChange', muts[0].target.attributes.lang.value)
+        }
 
         for (const mut of muts) {
 

--- a/DomReady/StateWatcher.js
+++ b/DomReady/StateWatcher.js
@@ -33,15 +33,15 @@ class StateWatcher extends EventEmitter {
     observe() {
         this.observer.disconnect();
         let mutation = { childList: true, subtree: true };
-        this.observer.observe(document.querySelector(".app .layers"), mutation);
-        this.observer.observe(document.querySelector("html"), { attributes: true })
+        this.observer.observe(document.querySelector('.app .layers'), mutation);
+        this.observer.observe(document.querySelector('html'), { attributes: true })
     }
 
     _onMutation(muts) {
         //console.log(muts);
 
         if (muts.length === 1 && muts[0].type === 'attributes' && muts[0].attributeName === 'lang') {
-            this.emit('languageChange', muts[0].target.attributes.lang.value)
+            this.emit('languageChange', muts[0].target.attributes.lang.value);
         }
 
         for (const mut of muts) {


### PR DESCRIPTION
Also adjust the StateWatcher to rewatch after language change.
The whole DOM tree gets rebuild, so old selectors
don't work anymore.
This adds a new event called languageChange as well. This could help
in creating multilanguage plugins.

Also fixes issue #34 