### PR TITLE
Adds a local (non caching) WebServer

### DIFF
--- a/DomReady/CssInjector.js
+++ b/DomReady/CssInjector.js
@@ -55,7 +55,7 @@ class CssInjector {
 
         readFile(location).then(css => {
             if (css.match(/url\([\'"]?.\//)) {
-                const base = window.DI.WebServer.base
+                const base = window.DI.WebServer.base;
                 css = css.replace(/url\(['"]?(.\/[^'"\)]+['"]?)/g, (match, path) => {
                     window.DI.WebServer.serve(path, window._path.join(window._path.dirname(location), path));
                     return 'url(' + base + path;

--- a/DomReady/CssInjector.js
+++ b/DomReady/CssInjector.js
@@ -54,6 +54,14 @@ class CssInjector {
             location = window._path.join(__dirname, '..', 'CSS', location);
 
         readFile(location).then(css => {
+            if (css.match(/url\([\'"]?.\//)) {
+                const base = window.DI.WebServer.base
+                css = css.replace(/url\(['"]?(.\/[^'"\)]+['"]?)/g, (match, path) => {
+                    window.DI.WebServer.serve(path, window._path.join(window._path.dirname(location), path));
+                    return 'url(' + base + path;
+                });
+            }
+
             this.rawCss = css;
 
             if (this.styleTag == null) {

--- a/DomReady/Views/SettingsGeneral.js
+++ b/DomReady/Views/SettingsGeneral.js
@@ -1,7 +1,7 @@
 const e = window.DI.React.createElement;
 
-const { SettingsSection, SettingsDivider, SettingsOptionTextbox, SettingsOptionFilebox,
-    SettingsTitle, SettingsDescription } = window.DI.require('./Structures/Components');
+const { SettingsDivider, SettingsOptionTextbox, SettingsOptionFilebox, SettingsExpandableSection, SettingsOptionDescription, SettingsOptionToggle 
+    } = window.DI.require('./Structures/Components');
 
 class SettingsGeneral extends window.DI.React.Component {
     render() {
@@ -26,6 +26,20 @@ class SettingsGeneral extends window.DI.React.Component {
                 reset: true
             }),
             e(SettingsDivider),
+            e(SettingsExpandableSection, { title: 'Expert settings', components: [
+                e(SettingsOptionDescription, { 
+                    text: 'Attention: These settings may break several things in your Discord Injections installation. ' +
+                          'Make sure you know what you are doing!'
+                }),
+                e(SettingsOptionToggle, {
+                    title: 'Internal Webserver',
+                    description: 'This controls the internal webserver that is used as a wrapper around local file requests. If you don\'t use local imports, it is safe to disable.',
+                    plugin: this.props.plugin,
+                    lsNode: 'webServer',
+                    defaultValue: true,
+                    onSave: () => window.DI.WebServer.listen()
+                }),
+            ] }),
             e(require('./SettingsSync'), { title: 'Settings Sync', plugin: this.props.plugin })
         );
     }

--- a/DomReady/WebServer.js
+++ b/DomReady/WebServer.js
@@ -1,0 +1,85 @@
+/**
+ * The Internal WebServer, do not modify this
+ */
+
+
+const http = require('http');
+const lookup = require('mime-types').contentType
+
+class WebServer {
+    constructor() {
+        this.server = http.createServer(this.onRequest.bind(this));
+        // listen on localhost on a random port
+        this.listen();
+
+        this.paths = {};
+    }
+
+    get enabled() {
+        let settings = {webServer: true}
+        const diNode = DI.localStorage.getItem('DI-DiscordInjections');
+        if (diNode) {
+            try {
+                // overwrite default with user setting
+                settings = Object.assign(settings, JSON.parse(diNode));
+            } catch (ex) {}
+
+            return settings.webServer;
+        }
+    }
+
+    get base() {
+        const addr = this.server.address();
+        return `http://${addr.address}:${addr.port}/`;
+    }
+
+    serve(path, location) {
+        if (!this.enabled) {
+            console.error('[WebServer] disabled, but asked to serve', path);
+            return
+        }
+
+        // strip beginning ./ if needed
+        if (path.startsWith('./')) {
+            path = path.substr(2);
+        }
+
+        this.paths[path] = location;
+        console.log('[WebServer] Serving', this.base + path, 'from', location);
+    }
+
+    listen() {
+        if (!this.enabled && this.server.listening) {
+            this.server.close();
+            console.log('WebServer closed')
+        } else if (!this.server.listening && this.enabled) {
+            this.server.listen(0, 'localhost', () => {
+                console.log('WebServer running on ' + this.base);
+            });
+        }
+    }
+
+    onRequest(req, res) {
+        req.url = req.url.substr(1); // strip leading /
+
+        if (!this.paths[req.url]) {
+            console.log('[WebServer] 404', req.url);
+            res.writeHead(404, { 'Access-Control-Allow-Origin': '*' });
+            return res.end();
+        }
+
+        window._fs.readFile(this.paths[req.url], null, (err, data) => {
+            if (err) {
+                console.log('[WebServer] 500', req.url);
+                res.writeHead(500, { 'Content-Type': 'text/plain;charset=utf-8', 'Access-Control-Allow-Origin': '*' });
+                return res.end(err.toString(), 'utf-8');
+            }
+
+            console.log('[WebServer] 200', req.url);
+            res.writeHead(200, { 'Content-Type': lookup(this.paths[req.url]) || 'application/octet-stream', 'Access-Control-Allow-Origin': '*' });
+            res.end(data);
+        })
+    }
+}
+
+module.exports = WebServer;

--- a/DomReady/index.js
+++ b/DomReady/index.js
@@ -39,6 +39,7 @@ const PluginManager = require('./PluginManager');
 const StateWatcher = require('./StateWatcher');
 const SettingsSync = require('./SettingsSync');
 const DISettings = require('./DISettings');
+const WebServer = require('./WebServer')
 
 DI.StateWatcher = new StateWatcher();
 DI.DISettings = new DISettings();
@@ -53,3 +54,4 @@ DI.SettingsSync = new SettingsSync();
 DI.CssInjector = new CssInjector();
 DI.PluginManager = new PluginManager();
 DI.CommandHandler = new CommandHandler();
+DI.WebServer = new WebServer();

--- a/Structures/Components/SettingsOptionBase.js
+++ b/Structures/Components/SettingsOptionBase.js
@@ -18,8 +18,9 @@ class SettingsOptionBase extends window.DI.React.Component {
     }
 
     setProp(newVal) {
+        const result = this.plugin.setSettingsNode(this.props.lsNode, newVal);
         if (typeof this.props.onSave === 'function') this.props.onSave();
-        return this.plugin.setSettingsNode(this.props.lsNode, newVal);
+        return result;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bluebird": "^3.5.0",
     "discord.js": "^11.1.0",
     "eventemitter3": "^2.0.3",
+    "mime-types": "^2.1.16",
     "mkdirp": "^0.5.1",
     "moment": "^2.18.1",
     "ps-node": "^0.1.5",


### PR DESCRIPTION
This adds a new dependency 'mime-types' - but that one's already
in the node_modules, so no new `npm install` required. (I
specifically chose this module because of no new dependency needed).

The WebServer can be disabled in the settings and every file needs
to be specifically defined for imports, so no random file access is
allowed. If you are paranoid, you can disable the WebServer, but
some things may break.