### PR TITLE
Allow for custom file filters and properties for `SettingsOptionFilebox`es

### DIFF
--- a/DomReady/Views/SettingsGeneral.js
+++ b/DomReady/Views/SettingsGeneral.js
@@ -12,6 +12,10 @@ class SettingsGeneral extends window.DI.React.Component {
                 plugin: this.props.plugin,
                 lsNode: 'cssPath',
                 defaultValue: 'style.css',
+                dialog: {
+                    title: 'Select CSS file',
+                    filters: [{ name: 'CSS Files', extensions: ['css'] }],
+                },
                 reset: true,
                 apply: true,
                 onApply: () => window.DI.CssInjector.refresh()

--- a/Structures/Components/SettingsOptionFilebox.js
+++ b/Structures/Components/SettingsOptionFilebox.js
@@ -121,15 +121,27 @@ class SettingsOptionFilebox extends Base {
         this.apply(event);
     }
 
+    static get fileDialogDefaults() {
+        return {
+            title: 'Select a file',
+            filters: [{ name: 'All Files', extentions: ['*'] }],
+            properties: ['openFile'],
+            required: false
+        }
+    }
+
     fileSelector() {
-        let _this = this;
-        dialog.showOpenDialog({
-            title: 'Select CSS file',
-            filters: [{ name: 'CSS Files', extensions: ['css'] }],
-            properties: ['openFile']
-        }, function (filePath) {
-            _this.setState({ value: filePath[0] });
-        });
+        let defaultDialogOptions = Object.assign({}, this.fileDialogDefaults, this.props.dialog);
+        dialog.showOpenDialog(defaultDialogOptions, (filePath) => {
+            if (!filePath || !filePath.length) {
+                if (this.props.dialog.required) {
+                    dialog.showMessageBox({ type: 'warning', message: 'You need to select a file.' });
+                    this.fileSelector();
+                }
+                return;
+            }
+            this.setState({ value: filePath[0], values: filePath });
+        })
     }
 }
 


### PR DESCRIPTION
### Systems Tested On

Client:
 - [X] Stable
 - [ ] PTB
 - [X] Canary
 - [ ] Development

OS:
 - [X] Windows
 - [ ] Mac
 - [ ] Linux (include distro)

### Description

This PR allows the file dialog for SettingsOptionFilebox.js to be more customizable, specifically allowing you to specify a title, file filters and properties. 
In addition to that, the callback that processes the new path now also checks if the path exists. It won't if an empty path is specified or if the user presses Cancel instead of selecting a file. There is also a property on the `dialog` object passed, `dialog.required`. This property can prevent the user from canceling (forcing them to select a file). 
The settings tab for Custom CSS in `SettingsGeneral.js` has also been adapted to the proposed syntax. 


### Additional Comments

Open to any criticism or questions. 😄 