### PR TITLE
Add backwards compatibility with BD

### DIFF
--- a/DomReady/CssInjector.js
+++ b/DomReady/CssInjector.js
@@ -1,6 +1,7 @@
 /**
  * The CSS injector, do not modify this
  */
+const reBDMeta = /\/\/META{.*}\*\/\//;
 
 function readFile(path, encoding = 'utf-8') {
     return new Promise((resolve, reject) => {
@@ -49,6 +50,8 @@ class CssInjector {
     }
 
     parseFile(content, location) {
+        content = content.replace(reBDMeta, '');
+
         if (content.match(/url\([\'"]?.\//)) {
             const base = window.DI.WebServer.base;
             return content.replace(/url\(['"]?(.\/[^'"\)]+)['"]?/g, (match, path) => {


### PR DESCRIPTION
### Systems Tested On

Client:
 - [X] Stable
 - [ ] PTB
 - [X] Canary
 - [ ] Development

OS:
 - [X] Windows
 - [ ] Mac
 - [X] Linux (Gentoo)

### Description

This PR will make DI's CSS injector ignore the `META` tags you find on BetterDiscord themes. Those tags will break the first line of CSS, unless the theme creator escapes it by appending `{}` (an empty CSS rule). Theme creators don't always do this, and as a result those themes are often broken on DI. This PR basically adds backwards compatibility with BetterDiscord themes.