### PR TITLE
Re-apply badges on message edits

### DIFF
--- a/engine/plugins/contrib/index.js
+++ b/engine/plugins/contrib/index.js
@@ -25,6 +25,11 @@ module.exports = class hooks extends Plugin {
         )
       } else if (node.classList.contains('message-group')) {
         this.applyBadge(node)
+      } else if (
+        node.classList.contains('edit-container-outer') || // Entered message editor
+        node.classList.contains('old-h2') // Exited message editor
+      ) {
+        this.applyBadge(node.closest('.message-group'))
       }
     })
   }


### PR DESCRIPTION
At the moment, if a contributor edits their own message, the badge on that message disappears for them. This commit re-applies the badge when that happens.