### PR TITLE
Add Badges to Repo Page & Implement Plugin Update Functionality 

### DIFF
--- a/engine/plugins/plugins/SettingsRepositoryPage.jsx
+++ b/engine/plugins/plugins/SettingsRepositoryPage.jsx
@@ -97,7 +97,7 @@ module.exports = class SettingsRepositoryPage extends React.PureComponent {
       ? parseAuthor(entry.package.author)
       : null
 
-    const alreadyInstalled = this.state.plugins.has(entry.package.name)
+    const alreadyInstalled = this.state.plugins.get(entry.package.name)
 
     let debug = null
     if (this.props.plugin.debugEnabled) {
@@ -175,7 +175,13 @@ module.exports = class SettingsRepositoryPage extends React.PureComponent {
 
           <div>
             {alreadyInstalled
-              ? null
+              ? alreadyInstalled.package.version !== entry.package.version
+                ? <Button
+                  outline
+                  className='DI-plugins-button-update'
+                  onClick={() => this.install(entry.package, true)}
+                />
+                : null
               : <Button
                 outline
                 className='DI-plugins-button-install'
@@ -188,21 +194,21 @@ module.exports = class SettingsRepositoryPage extends React.PureComponent {
     )
   }
 
-  async install (pkg) {
+  async install (pkg, update = false) {
     if (
       dialog.showMessageBox(getCurrentWindow(), {
         type: 'question',
-        title: 'Install Plugin',
-        message: `Do you really want to install "${pkg.name}"?`,
+        title: `${update ? 'Update' : 'Install' } Plugin`,
+        message: `Do you really want to ${update ? 'update' : 'install'} "${pkg.name}"?`,
         buttons: ['Yes', 'No'],
         defaultId: 0,
         cancelId: 1
       }) !== 0
     ) {
-      return this.props.plugin.debug('Aborting install of', pkg.name)
+      return this.props.plugin.debug('Aborting', update ? 'update' : 'install', 'of', pkg.name)
     }
 
-    this.props.plugin.debug('Installing', pkg.name)
+    this.props.plugin.debug(update ? 'Updating...' : 'Installing', pkg.name)
 
     // grab the package info
     const info = await npmFetch(
@@ -211,7 +217,9 @@ module.exports = class SettingsRepositoryPage extends React.PureComponent {
     this.setState({ loading: true }, async () => {
       await this.props.plugin.install(
         pkg.name,
-        info.versions[info['dist-tags'].latest].dist.tarball
+        info.versions[info['dist-tags'].latest].dist.tarball,
+        undefined,
+        update
       )
       this.setState({
         loading: false,

--- a/engine/plugins/plugins/SettingsRepositoryPage.jsx
+++ b/engine/plugins/plugins/SettingsRepositoryPage.jsx
@@ -123,9 +123,17 @@ module.exports = class SettingsRepositoryPage extends React.PureComponent {
       <SettingsPanel>
         <div className='DI-plugin-infobox' data-plugin-id={entry.package.name}>
           <div className='DI-plugin-meta'>
-            <strong>
-              {entry.package.name} <em>v{entry.package.version}</em>
-            </strong>
+            
+          <strong
+            className={`DI-plugin-type-${entry.package.keywords.includes('di-theme') ? 'theme' : 'plugin'}`}
+            style={{
+              backgroundImage: `url(${entry.icon ||
+                'https://discordinjections.xyz/img/logo-alt-nobg.svg'}`
+            }}
+          >
+            {entry.package.name}
+          </strong>
+
 
             <p>
               {entry.package.description}

--- a/engine/plugins/plugins/index.js
+++ b/engine/plugins/plugins/index.js
@@ -82,12 +82,16 @@ module.exports = class plugins extends Plugin {
     this.setPluginInfo(pkgName, 'path', installPath)
   }
 
-  async install (pkgName, pkgDownload = null, force = false) {
+  async install (pkgName, pkgDownload = null, force = false, update = false) {
     try {
       let installPath = pkgName
 
       if (pkgDownload) {
         installPath = path.join(this.manager.basePath, pkgName)
+        if (update) { // remove old plugin folder, if doing an update
+          await this.manager.unload(pkgName)
+          await fs.remove(installPath)
+        }
         const dlPath = path.join(this.manager.basePath, '_' + pkgName)
         this.debug('Downloading', pkgName, 'to', dlPath)
         await download(pkgDownload, dlPath, { extract: true })

--- a/engine/plugins/plugins/style.css
+++ b/engine/plugins/plugins/style.css
@@ -153,6 +153,22 @@
   min-height: 0;
 }
 
+.DI-plugins-button-update {
+  background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4gICAgPHBhdGggZD0iTTE2IDEzaC0zVjNoLTJ2MTBIOGw0IDQgNC00ek00IDE5djJoMTZ2LTJINHoiIGZpbGw9IndoaXRlIi8+ICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz48L3N2Zz4=)
+    center center #ce72da;
+  background-repeat: no-repeat;
+  border-radius: 3px;
+  box-sizing: border-box;
+  height: 24px;
+  width: 24px;
+  font-size: 0;
+  transition: background-color ease .2s;
+  margin-bottom: 5px;
+  border: none;
+  min-width: 0;
+  min-height: 0;
+}
+
 #DI-plugins-plugin .DI-checkbox-unchecked {
   background-color: #333 !important;
   border-width: 2px;


### PR DESCRIPTION
This PR adds the plugin/theme badges to the "Customize DI" settings tab, and creates a button if the installed version differs from the latest NPM version.

Updating is done by using the same install protocol, but deleting the installPath and unloading the plugin beforehand.