### PR TITLE
check process arguments

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -17,7 +17,12 @@ Object.assign(exports, {
       .map(p => {
         let command = p.command
         while (!fs.existsSync(command)) {
-          command += ' ' + p.arguments.shift()
+          // what to do if there's no arguments or existing file?
+          if (p.arguments.length === 0) break;
+          if (typeof p.arguments === 'string')
+            command += ' ' + p.arguments;
+          else
+            command += ' ' + p.arguments.shift()
         }
         p.command = command
         return p


### PR DESCRIPTION
process.arguments is a string when there's no arguments provided or (assumedly) only one argument is provided

topic of discussion: if a file cannot be found and there are no arguments, what course of action should be taken? throwing an error? returning the object anyways?

this pr is in regards to #148 